### PR TITLE
Add gatsby-plugin to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "keywords": [
     "gatsby",
     "plugin",
+    "gatsby-plugin",
     "zygote"
   ],
   "main": "gatsby-browser.js",


### PR DESCRIPTION
Including the keyword `gatsby-plugin` in the `package.json` will make this plugin discoverable in the [Gatsby plugin library](https://www.gatsbyjs.org/plugins/) once Algolia indexes it 🙂

If you'd like people to be able to find your plugin there, this would help! 

Refers to this issue: https://github.com/gatsbyjs/gatsby/issues/14013